### PR TITLE
Remove -g flag

### DIFF
--- a/core/combo/TARGET_linux-arm64.mk
+++ b/core/combo/TARGET_linux-arm64.mk
@@ -129,7 +129,7 @@ TARGET_GLOBAL_CPPFLAGS += -fvisibility-inlines-hidden
 # More flags/options can be added here
 TARGET_RELEASE_CFLAGS := \
 			-DNDEBUG \
-			-O2 -g \
+			-O2 \
 			-Wstrict-aliasing=2 \
 			-fgcse-after-reload \
 			-frerun-cse-after-loop \


### PR DESCRIPTION
You can read https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
This is probably not required and does not affect the debug info
