### PR TITLE
Add a PNG app optimizer

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1178,8 +1178,13 @@ INTERNAL_SYSTEMIMAGE_FILES := $(filter $(TARGET_OUT)/%, \
     $(RECOVERY_RESOURCE_ZIP) \
     $(RECOVERY_PATCH_INSTALL))
 
+systemimage-crusher: $(INTERNAL_SYSTEMIMAGE_FILES)
+	@echo -e "Optimizing PNGs to Shrink ROM Size!"
+	$(hide) APKCERTS=$(APKCERTS_FILE) ./build/tools/releasetools/pngcrusher
 
-FULL_SYSTEMIMAGE_DEPS := $(INTERNAL_SYSTEMIMAGE_FILES) $(INTERNAL_USERIMAGES_DEPS)
+.PHONY: systemimage-crusher
+
+FULL_SYSTEMIMAGE_DEPS := $(INTERNAL_SYSTEMIMAGE_FILES) $(INTERNAL_USERIMAGES_DEPS) systemimage-crusher
 # -----------------------------------------------------------------
 # installed file list
 # Depending on anything that $(BUILT_SYSTEMIMAGE) depends on.

--- a/tools/releasetools/crush
+++ b/tools/releasetools/crush
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 The MoKee OpenSource Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+TMPDIR=/tmp/pngcrusher-$$
+BASE=$(pwd)
+
+if [ -e "$1" ];then
+    NAME=$(basename $1)
+    echo -e $CL_YLW"Optimize:"$CL_RST" $NAME.."
+
+    APKINFO=$(grep "name=\"$NAME\"" $APKCERTS)
+    [ $QUIET ] || echo "APKINFO: $APKINFO"
+    if [ "$APKINFO" = "" ];then
+        echo -e $CL_YLW"No apk info for $NAME, might be prebuilt, skipping"$CL_RST
+        exit 1
+    fi
+    CERT=$(echo $APKINFO | awk {'print $2'} | cut -f 2 -d "=" | tr -d "\"")
+    KEY=$(echo $APKINFO | awk {'print $3'} | cut -f 2 -d "=" | tr -d "\"")
+    if [ "$CERT" = "" ];then
+        echo -e $CL_RED"No certificate for $NAME"$CL_RST
+        exit 1
+    elif [ "$CERT" = "PRESIGNED" ];then
+        echo -e $CL_YLW"$NAME is presigned, skipping"$CL_RST
+        exit 1
+    elif [ "$NAME" = "webview.apk" ];then
+        echo -e $CL_YLW"$NAME is special, skipping"$CL_RST
+        exit 1
+    fi
+
+    [ $QUIET ] || echo -e $CL_YLW"Certificate:"$CL_RST" $CERT"
+
+    [ -d $TMPDIR/$NAME ] && rm -rf $TMPDIR/$NAME
+    mkdir -p $TMPDIR/$NAME
+    trap "rm -rf $TMPDIR; exit" INT TERM EXIT
+    cd $TMPDIR/$NAME
+    unzip -q $BASE/$1
+    PNG_FILES=$(find . -name "*.png" | grep -v "\.9.png$" | tr "\n" " ")
+    for x in $PNG_FILES;do
+        [ $QUIET ] || echo -e $CL_YLW"Crushing $x"$CL_RST
+        optimize_png $x
+    done
+    cp $BASE/$1 $BASE/$1.old
+
+    [ $QUIET ] || echo -e $CL_YLW"Repacking apk.."$CL_RST
+    aapt p -0 .dat -0 .dict -0 .arsc -F $NAME .
+
+    [ $QUIET ] || echo -e $CL_YLW"Resigning with cert: $(echo $CERT)"$CL_RST
+
+    [ $QUIET ] || echo java -jar $ANDROID_HOST_OUT/framework/signapk.jar $ANDROID_BUILD_TOP/$CERT $ANDROID_BUILD_TOP/$KEY $NAME signed_$NAME
+    java -jar $ANDROID_HOST_OUT/framework/signapk.jar $ANDROID_BUILD_TOP/$CERT $ANDROID_BUILD_TOP/$KEY $NAME signed_$NAME
+    [ $QUIET ] || echo -e $CL_YLW"Zipaligning.."$CL_RST
+
+    zipalign -f 4 signed_$NAME $BASE/$1
+    if [ ! $QUIET ];then
+        ls -l $BASE/$1.old
+        ls -l $BASE/$1
+    fi
+    rm $BASE/$1.old
+else
+    echo "Usage: $0 [apk file]"
+fi

--- a/tools/releasetools/crush
+++ b/tools/releasetools/crush
@@ -40,6 +40,9 @@ if [ -e "$1" ];then
     elif [ "$NAME" = "webview.apk" ];then
         echo -e $CL_YLW"$NAME is special, skipping"$CL_RST
         exit 1
+    elif [ "$NAME" = "Gello.apk" ];then
+        echo -e $CL_YLW"$NAME is special, skipping"$CL_RST
+        exit 1
     fi
 
     [ $QUIET ] || echo -e $CL_YLW"Certificate:"$CL_RST" $CERT"

--- a/tools/releasetools/pngcrusher
+++ b/tools/releasetools/pngcrusher
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 The MoKee OpenSource Project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Some command line magic
+export QUIET=1
+export BRUTECRUSH="-brute"
+
+if [ ! "$BUILD_WITH_COLORS" = "0" ];then
+    export CL_RED="\033[31m"
+    export CL_GRN="\033[32m"
+    export CL_YLW="\033[33m"
+    export CL_BLU="\033[34m"
+    export CL_MAG="\033[35m"
+    export CL_CYN="\033[36m"
+    export CL_RST="\033[0m"
+fi
+
+if [ -z "$BRUTE_PNGCRUSH" ];then
+    export BRUTECRUSH=""
+fi
+
+# Get the path of apkcerts.txt
+if [ -z "$OUT" -o ! -d "$OUT" ];then
+    echo -e $CL_RED"ERROR: $0 only works with a full build environment. $OUT should exist."$CL_RST
+    exit 1
+fi
+
+if [ -z "$APKCERTS" ];then
+    INTER=$(ls $OUT/obj/PACKAGING/target_files_intermediates | grep zip | cut -d'.' -f1)
+    export APKCERTS=$OUT/obj/PACKAGING/target_files_intermediates/$INTER/META/apkcerts.txt
+
+    if [ ! -f "$APKCERTS" ];then
+        echo -e $CL_RED"set APKCERTS to the path to your apkcerts.txt file"$CL_RST
+        exit 1
+    fi
+fi
+
+if [ ! -f "$APKCERTS" ];then
+    echo -e $CL_RED"Invalid path to apkcerts.txt, set APKCERTS to the correct path."$CL_RST
+fi
+
+# Decide which tool to use
+if [ "$(which pngquant)" != "" ];then
+    optimize_png () {
+        pngquant --speed 1 --force --ext .png $1 1> /dev/null 2> /dev/null
+    }
+elif [ "$(which pngcrush)" != "" ];then
+    optimize_png () {
+        pngcrush -q ${BRUTECRUSH} $1 ${1}.out 1> /dev/null 2> /dev/null
+        mv ${1}.out ${1}
+    }
+elif [ "$(which optipng)" != "" ];then
+    optimize_png () {
+        optipng -o7 -quiet $1 1> /dev/null 2> /dev/null
+    }
+elif [ "$(which pngout-static)" != "" ];then
+    optimize_png () {
+        pngout-static $1
+    }
+elif [ "$(which pngout)" != "" ];then
+    optimize_png () {
+        pngout $1
+    }
+else
+    echo -e $CL_RED"Please install pngquant, pngcrush, optipng, or pngout"$CL_RST
+    exit
+fi
+
+export -f optimize_png
+
+# Compulsory tools
+if [ "$(which aapt)" = "" ];then
+    echo -e $CL_RED"Please ensure aapt is in your \$PATH"$CL_RST
+    exit 1
+fi
+
+if [ "$(which zipalign)" = "" ];then
+    echo -e $CL_RED"Please ensure zipalign is in your \$PATH"$CL_RST
+    exit 1
+fi
+
+# Notify
+echo -e $CL_GRN"--- Starting pngcrusher ---"$CL_RST
+echo -e $CL_BLU"apkcerts.txt path: "$CL_RST"$APKCERTS"
+
+# Setup args
+OUT_TARGET_HOST=$(uname -s)
+if [ x"$OUT_TARGET_HOST" = x"Linux" ];then
+    OUT_TARGET_HOST=linux-x86
+    XARGS="xargs --max-args=1 --max-procs $(grep 'processor' /proc/cpuinfo|wc -l)"
+elif [ x"$OUT_TARGET_HOST" = x"Darwin" ];then
+    OUT_TARGET_HOST=darwin-x86
+    XARGS="xargs -n 1 -P $(sysctl hw.ncpu | awk '{print $2}')"
+else
+    echo -e $CL_RED"ERROR: unknown/unsupported host OS!"$CL_RST
+    exit 1
+fi
+
+# Start crushing
+cd $OUT/system
+find framework/ app/ priv-app/ vendor/app/ -name \*.apk -print | $XARGS $ANDROID_BUILD_TOP/build/tools/releasetools/crush
+
+echo -e $CL_GRN"--- pngcrusher done ---"$CL_RST


### PR DESCRIPTION
Test Ok on my last builds only app that did not like it was Gello add a if to prevent the opt of it.

Works depends on the install of pngquant, pngcrush, optipng, or pngout
https://github.com/ResurrectionRemix/android_build/compare/marshmallow...bhb27:marshmallow?expand=1#diff-a5c4250b9c4b3cc04da68fcf6d5210b9R80

I test only with pngquant, the opt process of apps is really fast.

Final ROM is 14MB smaller.
