### PR TITLE
Build: call rr_variant and changelog after export ANDROID_BUILD_TOP

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,4 +1,3 @@
-. vendor/cm/tools/rr_variant.sh && ./vendor/cm/tools/changelog.sh &&
 function hmm() {
 cat <<EOF
 Invoke ". build/envsetup.sh" from your shell to add the following functions to your environment:
@@ -1717,6 +1716,6 @@ check_bash_version && {
 }
 
 export ANDROID_BUILD_TOP=$(gettop)
-
+. vendor/cm/tools/rr_variant.sh && ./vendor/cm/tools/changelog.sh &&
 . vendor/cm/build/envsetup.sh
 


### PR DESCRIPTION
bash: /vendor/cm/tools/colors: No such file or directory
ANDROID_BUILD_TOP is not yet exported them no colors and error on the first time the  . build/envsetup.sh is call
as you try the second time without closing the terminal is all fine because envsetup.sh has already load it

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>