### PR TITLE
Show "ro.sf.lcd_density" param only if exists

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -699,7 +699,10 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     buildday = GetBuildProp("ro.build.date", OPTIONS.info_dict)
     securep = GetBuildProp("ro.build.version.security_patch", OPTIONS.info_dict)
     buildhst = GetBuildProp("ro.build.host", OPTIONS.info_dict)
+
+  if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None:
     density = GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict)
+
     device = GetBuildProp("ro.rr.device", OPTIONS.info_dict)
     androidver = GetBuildProp("ro.build.version.release", OPTIONS.info_dict)
     manufacturer = GetBuildProp("ro.product.manufacturer", OPTIONS.info_dict)
@@ -729,8 +732,11 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     script.Print(" Device codename: %s"%(device));
     script.Print("");
     script.Print(" Manufacturer: %s"%(manufacturer));
+
+  if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None:
     script.Print("");
     script.Print(" LCD density: %s"%(density));
+
     script.Print("");
     script.Print(" *******************************************");
   
@@ -890,8 +896,8 @@ def GetBuildProp(prop, info_dict):
   try:
     return info_dict.get("build.prop", {})[prop]
   except KeyError:
-    raise common.ExternalError("couldn't find %s in build.prop" % (prop,))
-
+    print ("WARNING: couldn't find %s in build.prop" % (prop,))
+    return None
 
 def AddToKnownPaths(filename, known_paths):
   if filename[-1] == "/":

--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -699,10 +699,7 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     buildday = GetBuildProp("ro.build.date", OPTIONS.info_dict)
     securep = GetBuildProp("ro.build.version.security_patch", OPTIONS.info_dict)
     buildhst = GetBuildProp("ro.build.host", OPTIONS.info_dict)
-
-  if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None:
-    density = GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict)
-
+    if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None: density = GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict)
     device = GetBuildProp("ro.rr.device", OPTIONS.info_dict)
     androidver = GetBuildProp("ro.build.version.release", OPTIONS.info_dict)
     manufacturer = GetBuildProp("ro.product.manufacturer", OPTIONS.info_dict)
@@ -732,11 +729,8 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     script.Print(" Device codename: %s"%(device));
     script.Print("");
     script.Print(" Manufacturer: %s"%(manufacturer));
-
-  if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None:
-    script.Print("");
-    script.Print(" LCD density: %s"%(density));
-
+    if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None: script.Print("");
+    if GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict) is not None: script.Print(" LCD density: %s"%(density));
     script.Print("");
     script.Print(" *******************************************");
   


### PR DESCRIPTION
Some devices (A6020 for example), do not have this parameter set in system.prop (https://github.com/boulzordev/android_device_lenovo_A6020/blob/cm-14.1/system.prop), is set in init https://github.com/boulzordev/android_device_lenovo_A6020/blob/cm-14.1/init/init_A6020.cpp#L73