### PR TITLE
dumpvar: Remove unnecessary print variables

### DIFF
--- a/core/dumpvar.mk
+++ b/core/dumpvar.mk
@@ -126,8 +126,6 @@ endif # CALLED_FROM_SETUP
 
 ifneq ($(PRINT_BUILD_CONFIG),)
 $(info ============================================)
-$(info   RR_VERSION=$(CM_VERSION))
-$(info   DEVICE=$(CM_BUILD))
 $(foreach v, $(print_build_config_vars),\
   $(info $v=$($(v))))
 $(info ============================================)


### PR DESCRIPTION
 * RR_VERSION is already in print list, so remove it
   Moreover it has the old CM_VERSION value

 * DEVICE(=CM_BUILD) not so useful

Change-Id: I9e1af132547ea606cd8bea08fed23a942faccd35