### PR TITLE
build: Use android unzip binary instead of busybox

### DIFF
--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -172,7 +172,7 @@ class EdifyGenerator(object):
 
   def FlashMagisk(self):
     self.script.append('package_extract_dir("magisk", "/tmp/magisk");')
-    self.script.append('run_program("/sbin/busybox", "unzip", "/tmp/magisk/magisk.zip", "META-INF/com/google/android/*", "-d", "/tmp/magisk");')
+    self.script.append('run_program("/sbin/unzip", "/tmp/magisk/magisk.zip", "META-INF/com/google/android/*", "-d", "/tmp/magisk");')
     self.script.append('run_program("/sbin/sh", "/tmp/magisk/META-INF/com/google/android/update-binary", "dummy", "1", "/tmp/magisk/magisk.zip");')
 
   def ShowProgress(self, frac, dur):


### PR DESCRIPTION
 * Busybox is missing on some targets and this entails not installed Magisk root.
   Fix it using the android unzip binary.

Change-Id: I72f77d744156b731663d2426c1f90439e6c98701
Signed-off-by: Chippa-a <vusal1372@gmail.com>