### PR TITLE
[2/2] Make Magisk flashing opt-out

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -824,6 +824,7 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   script.WriteRawImage("/boot", "boot.img")
 
   if block_based:
+    if os.getenv('EXCLUDE_MAGISK','false') != 'true' :
     script.Print(" ")
     script.Print("Flashing Magisk...")
     script.Print(" ")


### PR DESCRIPTION
Create an environment variable EXCLUDE_MAGISK and set it to true for including magisk or flase for not.