### PR TITLE
Don't build MusicFX

### DIFF
--- a/target/product/generic_no_telephony.mk
+++ b/target/product/generic_no_telephony.mk
@@ -23,7 +23,6 @@ PRODUCT_PACKAGES := \
     Camera2 \
     Gallery2 \
     Music \
-    MusicFX \
     OneTimeInitializer \
     Provision \
     SystemUI \


### PR DESCRIPTION
After this :
https://github.com/ResurrectionRemix/android_vendor_resurrection/commit/0454ffda087cf4e75b3c4119637a8fa38b466495
MusicFX is still builded by default. Don't build two equalizers to avoid conflicts.