### PR TITLE
build: Add new variable to hold generic build properties

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -128,6 +128,10 @@ else
   endif
 endif
 
+#
+# -----------------------------------------------------------------
+# Add Lineage generic properties to the build properties.
+ADDITIONAL_BUILD_PROPERTIES += $(PRODUCT_GENERIC_PROPERTIES)
 
 # Bring in standard build system definitions.
 include $(BUILD_SYSTEM)/definitions.mk


### PR DESCRIPTION
This allows us to mark global Lineage properties as generic,
and thus getting them populated into /system/build.prop.

Change-Id: I2fd50706618e28fc9f3cc0860fdb0201c70ed660