### PR TITLE
When compiling, use release-keys tag not dev-keys

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -304,7 +304,7 @@ endif
 ifeq ($(DEFAULT_SYSTEM_DEV_CERTIFICATE),build/make/target/product/security/testkey)
 BUILD_KEYS := test-keys
 else
-BUILD_KEYS := dev-keys
+BUILD_KEYS := release-keys
 endif
 BUILD_VERSION_TAGS += $(BUILD_KEYS)
 BUILD_VERSION_TAGS := $(subst $(space),$(comma),$(sort $(BUILD_VERSION_TAGS)))


### PR DESCRIPTION
- Fix issues with some app requiring release-keys

Change-Id: Ia1352c5408670ed37b7ea529813fbb3df425003f
Signed-off-by: SagarMakhar <sagarmakhar@gmail.com>