### PR TITLE
Bump Security String to 2021-08-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-07-05
+      PLATFORM_SECURITY_PATCH := 2021-08-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0584   A-179289794  ID     High       8.1, 9, 10, 11
CVE-2021-0591   A-179386960  EoP    High       8.1, 9, 10, 11
CVE-2021-0593   A-179386068  EoP    High       8.1, 9, 10, 11
CVE-2021-0640   A-187957589  EoP    High       9, 10, 11
CVE-2021-0641   A-185235454  ID     High       8.1, 9, 10, 11
CVE-2021-0642   A-185126149  ID     High       8.1, 9, 10, 11
CVE-2021-0646   A-153352319  EoP    High       8.1, 9, 10, 11

Previously Implemented:
=======================
CVE:            References:  Type:  Severity:  Updated AOSP versions:  Prior Change:
CVE-2021-0519   A-176533109  ID     High       10, 11                  8adb0eb
                             EoP    High       8.1, 9

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0645   A-157320644  EoP    High       11

Change-Id: I058d30a872b972fb70b471bc339ff439c91f5bdb